### PR TITLE
CI: Simplify installation of cargo-msrv

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -52,8 +52,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-binstall
-      # For some reason caching (?) saves the cargo-msrv symlink, but not the
-      # actual binary. Hence, --force.
-      - run: cargo binstall --force -y --pkg-url="{ repo }/releases/download/v{ version }/{ name }_v{ version }_Linux_x86_64{ archive-suffix }" --pkg-fmt="tar" cargo-msrv
+          tool: cargo-msrv
       - run: cargo msrv verify


### PR DESCRIPTION
The next release of [cargo-msrv] will be installable with [cargo-binstall] (see [cargo-msrv #594]), which allows for this simplification of the CI job.

[cargo-msrv]: https://github.com/foresterre/cargo-msrv
[cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
[cargo-msrv #594]: https://github.com/foresterre/cargo-msrv/issues/594