### PR TITLE
Add `iter_matcher::render_stub()`

### DIFF
--- a/iter_matcher_tests/build.rs
+++ b/iter_matcher_tests/build.rs
@@ -25,12 +25,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Match and return (bool, &[u8]).")?;
+    writeln!(out, "#[cfg(not(feature = \"cargo-clippy\"))]")?;
     iter_matcher::Node::default()
         .add(b"aab", "(true, &[1, 1])")
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         .render(&mut out, "pub fn slice_in_tuple", "(bool, &'static [u8])")?;
+    writeln!(out)?;
+
+    writeln!(out, "#[cfg(feature = \"cargo-clippy\")]")?;
+    iter_matcher::render_stub(
+        &mut out,
+        "pub fn slice_in_tuple",
+        "(bool, &'static [u8])",
+    )?;
     writeln!(out)?;
 
     writeln!(out, "/// Decode basic HTML entities.")?;
@@ -43,6 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Decode all HTML entities.")?;
+    writeln!(out, "#[cfg(not(feature = \"cargo-clippy\"))]")?;
     let input = fs::read("html-entities.json")?;
     let input: serde_json::Map<String, serde_json::Value> =
         serde_json::from_slice(&input)?;
@@ -53,6 +63,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
     }))
     .render(&mut out, "pub fn all_entity_decode", "&'static str")?;
+    writeln!(out)?;
+
+    writeln!(out, "#[cfg(feature = \"cargo-clippy\")]")?;
+    iter_matcher::render_stub(
+        &mut out,
+        "pub fn all_entity_decode",
+        "&'static str",
+    )?;
     writeln!(out)?;
 
     Ok(())

--- a/iter_matcher_tests/src/lib.rs
+++ b/iter_matcher_tests/src/lib.rs
@@ -1,24 +1,2 @@
-#[cfg(not(feature = "cargo-clippy"))]
+// Include generated code.
 include!(concat!(env!("OUT_DIR"), "/test-matchers.rs"));
-
-// Stubs to make clippy happy. It is extremely slow with the real functions. See
-// https://github.com/rust-lang/rust-clippy/issues/10220
-
-macro_rules! stub {
-    ($name:ident, $ret:ty) => {
-        #[cfg(feature = "cargo-clippy")]
-        pub fn $name<'a, I>(iter: &mut I) -> Option<$ret>
-        where
-            I: Iterator<Item = &'a u8> + Clone,
-        {
-            // Just in case this actually gets used
-            iter.next();
-            None
-        }
-    };
-}
-
-stub!(all_entity_decode, &'static str);
-stub!(basic_entity_decode, u8);
-stub!(match_nothing, u8);
-stub!(match_nothing_true, bool);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,3 +274,12 @@ where
         });
     }
 }
+
+/// Render a stub function with the correct signature that does nothing.
+pub fn render_stub<W: io::Write, N: AsRef<str>, R: AsRef<str>>(
+    writer: &mut W,
+    fn_name: N,
+    return_type: R,
+) -> io::Result<()> {
+    Node::default().render(writer, fn_name, return_type)
+}


### PR DESCRIPTION
Sometimes it’s necessary to have a function that looks like a matcher but doesn’t actually do anything. For example, if your matcher is extremely long, it might be better to limit lints to a stub.

---

I think maybe it would be better to have a wrapper `Struct` that renders both the matcher and the stub.