### PR TITLE
IterMatcher → TreeMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/iter-matcher)][crates.io]
 ![Rust version 1.60+](https://img.shields.io/badge/Rust%20version-1.60%2B-success)
 
-[`IterMatcher`] can be used from a [build script] to generate a matcher
+[`TreeMatcher`] can be used from a [build script] to generate a matcher
 function. The function accepts an iterator over bytes and returns a mapped value
 if it finds a given byte sequence at the start of the iterator.
 
@@ -33,7 +33,7 @@ To create a matcher to handle the four basic HTML entities, use a build script
 like the following:
 
 ```rust
-use iter_matcher::IterMatcher;
+use iter_matcher::TreeMatcher;
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut out = BufWriter::new(File::create(out_path)?);
 
     writeln!(out, "/// Decode basic HTML entities.")?;
-    IterMatcher::new("pub fn entity_decode", "u8")
+    TreeMatcher::new("pub fn entity_decode", "u8")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
@@ -84,7 +84,7 @@ additional terms or conditions.
 
 [docs.rs]: https://docs.rs/iter-matcher/latest/iter_matcher/
 [crates.io]: https://crates.io/crates/iter-matcher
-[`IterMatcher`]: https://docs.rs/iter-matcher/latest/iter_matcher/struct.IterMatcher.html
+[`TreeMatcher`]: https://docs.rs/iter-matcher/latest/iter_matcher/struct.TreeMatcher.html
 [build script]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 [`position()`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position
 [memchr]: http://docs.rs/memchr

--- a/examples/cli-iter.rs
+++ b/examples/cli-iter.rs
@@ -1,10 +1,10 @@
-use iter_matcher::IterMatcher;
+use iter_matcher::TreeMatcher;
 use std::env;
 use std::io;
 use std::process::exit;
 
 fn main() {
-    let mut matcher = IterMatcher::new("pub fn matcher", "&'static str");
+    let mut matcher = TreeMatcher::new("pub fn matcher", "&'static str");
     env::args().skip(1).for_each(|arg| {
         let key_value: Vec<&str> = arg.splitn(2, '=').collect();
         if key_value.len() < 2 {

--- a/examples/cli-slice.rs
+++ b/examples/cli-slice.rs
@@ -1,10 +1,10 @@
-use iter_matcher::IterMatcher;
+use iter_matcher::TreeMatcher;
 use std::env;
 use std::io;
 use std::process::exit;
 
 fn main() {
-    let mut matcher = IterMatcher::new("pub fn matcher", "&'static str");
+    let mut matcher = TreeMatcher::new("pub fn matcher", "&'static str");
     env::args().skip(1).for_each(|arg| {
         let key_value: Vec<&str> = arg.splitn(2, '=').collect();
         if key_value.len() < 2 {

--- a/iter_matcher_tests/build.rs
+++ b/iter_matcher_tests/build.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut out = BufWriter::new(File::create(out_path)?);
 
     writeln!(out, "/// Match nothing.")?;
-    iter_matcher::Node::default().render_iter(
+    iter_matcher::TreeNode::default().render_iter(
         &mut out,
         "pub fn match_nothing",
         "u8",
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Match nothing (slice).")?;
-    iter_matcher::Node::default().render_slice(
+    iter_matcher::TreeNode::default().render_slice(
         &mut out,
         "pub fn match_nothing_slice",
         "u8",
@@ -26,15 +26,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Match nothing with Some(true).")?;
-    iter_matcher::Node::default().add(b"", "true").render_iter(
-        &mut out,
-        "pub fn match_nothing_true",
-        "bool",
-    )?;
+    iter_matcher::TreeNode::default()
+        .add(b"", "true")
+        .render_iter(&mut out, "pub fn match_nothing_true", "bool")?;
     writeln!(out)?;
 
     writeln!(out, "/// Match nothing with Some(true).")?;
-    iter_matcher::Node::default()
+    iter_matcher::TreeNode::default()
         .add(b"", "true")
         .render_slice(&mut out, "pub fn match_nothing_slice_true", "bool")?;
     writeln!(out)?;

--- a/iter_matcher_tests/build.rs
+++ b/iter_matcher_tests/build.rs
@@ -1,4 +1,4 @@
-use iter_matcher::IterMatcher;
+use iter_matcher::TreeMatcher;
 use std::env;
 use std::error::Error;
 use std::fs::{self, File};
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Match and return (bool, &[u8]).")?;
-    IterMatcher::new("pub fn slice_in_tuple", "(bool, &'static [u8])")
+    TreeMatcher::new("pub fn slice_in_tuple", "(bool, &'static [u8])")
         .add(b"aab", "(true, &[1, 1])")
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Match and return (bool, &[u8]).")?;
-    IterMatcher::new("pub fn slice_in_tuple_slice", "(bool, &'static [u8])")
+    TreeMatcher::new("pub fn slice_in_tuple_slice", "(bool, &'static [u8])")
         .add(b"aab", "(true, &[1, 1])")
         .add(b"aa", "(false, &[1, 1])")
         .add(b"ab", "(true, &[1])")
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Decode basic HTML entities.")?;
-    IterMatcher::new("pub fn basic_entity_decode", "u8")
+    TreeMatcher::new("pub fn basic_entity_decode", "u8")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     writeln!(out)?;
 
     writeln!(out, "/// Decode basic HTML entities.")?;
-    IterMatcher::new("pub fn basic_entity_decode_slice", "u8")
+    TreeMatcher::new("pub fn basic_entity_decode_slice", "u8")
         .add(b"&amp;", "b'&'")
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
@@ -82,7 +82,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let input: serde_json::Map<String, serde_json::Value> =
         serde_json::from_slice(&input)?;
     let mut matcher =
-        IterMatcher::new("pub fn all_entity_decode", "&'static str");
+        TreeMatcher::new("pub fn all_entity_decode", "&'static str");
     matcher.disable_clippy(true);
     matcher.extend(input.iter().map(|(name, info)| {
         (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-//! [`IterMatcher`] can be used from a [build script] to generate a function
+//! [`TreeMatcher`] can be used from a [build script] to generate a function
 //! that accepts an iterator over bytes and returns a mapped value if it finds a
 //! given byte sequence at the start of the iterator.
 //!
 //! # Example build script
 //!
 //! ```rust
-//! use iter_matcher::IterMatcher;
+//! use iter_matcher::TreeMatcher;
 //! use std::env;
 //! use std::error::Error;
 //! use std::fs::File;
@@ -19,7 +19,7 @@
 //!     let mut out = BufWriter::new(File::create(out_path)?);
 //!
 //!     writeln!(out, "/// My fancy matcher.")?;
-//!     IterMatcher::new("pub fn fancy_matcher", "&'static [u8]")
+//!     TreeMatcher::new("pub fn fancy_matcher", "&'static [u8]")
 //!         .add(b"one", r#"b"1""#)
 //!         .add(b"two", r#"b"2""#)
 //!         .add(b"three", r#"b"3""#)
@@ -83,7 +83,7 @@ use std::io;
 /// [memchr]: http://docs.rs/memchr
 /// [htmlize]: https://crates.io/crates/htmlize
 #[derive(Debug)]
-pub struct IterMatcher {
+pub struct TreeMatcher {
     /// The first part of the function definition to generate, e.g.
     /// `"pub fn matcher"`.
     pub fn_name: String,
@@ -100,7 +100,7 @@ pub struct IterMatcher {
     pub root: TreeNode,
 }
 
-impl IterMatcher {
+impl TreeMatcher {
     /// Create a new matcher (for use in a build script).
     ///
     /// This will generate a matcher with the the specified function name and
@@ -124,7 +124,7 @@ impl IterMatcher {
     /// Add a match.
     ///
     /// ```rust
-    /// let mut matcher = iter_matcher::IterMatcher::new("fn matcher", "u64");
+    /// let mut matcher = iter_matcher::TreeMatcher::new("fn matcher", "u64");
     /// matcher.add(b"a", "1");
     /// ```
     pub fn add<'a, K, V>(&mut self, key: K, value: V) -> &mut Self
@@ -159,11 +159,11 @@ impl IterMatcher {
     ///
     /// ```rust
     /// use bstr::ByteVec;
-    /// use iter_matcher::IterMatcher;
+    /// use iter_matcher::TreeMatcher;
     /// use pretty_assertions::assert_str_eq;
     ///
     /// let mut out = Vec::new();
-    /// let mut matcher = IterMatcher::new("fn match_bytes", "u64");
+    /// let mut matcher = TreeMatcher::new("fn match_bytes", "u64");
     /// matcher.disable_clippy(true);
     /// matcher.extend([("a".as_bytes(), "1")]);
     /// matcher.render_iter(&mut out).unwrap();
@@ -218,11 +218,11 @@ impl IterMatcher {
     ///
     /// ```rust
     /// use bstr::ByteVec;
-    /// use iter_matcher::IterMatcher;
+    /// use iter_matcher::TreeMatcher;
     /// use pretty_assertions::assert_str_eq;
     ///
     /// let mut out = Vec::new();
-    /// let mut matcher = IterMatcher::new("fn match_bytes", "u64");
+    /// let mut matcher = TreeMatcher::new("fn match_bytes", "u64");
     /// matcher.disable_clippy(true);
     /// matcher.extend([("a".as_bytes(), "1")]);
     /// matcher.render_slice(&mut out).unwrap();
@@ -262,7 +262,7 @@ impl IterMatcher {
     }
 }
 
-impl<'a, K, V> Extend<(K, V)> for IterMatcher
+impl<'a, K, V> Extend<(K, V)> for TreeMatcher
 where
     K: IntoIterator<Item = &'a u8>,
     V: Into<String>,
@@ -276,7 +276,7 @@ where
 
 /// A node in a tree matcher’s simple finite-state automaton.
 ///
-/// You probably want to use [`IterMatcher`] instead.
+/// You probably want to use [`TreeMatcher`] instead.
 #[derive(Debug, Default)]
 pub struct TreeNode {
     /// If the matcher gets to this node and `leaf` is `Some(_)`, then we found


### PR DESCRIPTION
I may yet change this to `IterMatcher` and `SliceMatcher`. Or perhaps I’ll make the iter/slice option a parameter on the `TreeMatcher` struct.