### PR TITLE
Make iterator v. slice a parameter on `TreeMatcher`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Since the matchers only check the start of the input, you will want to use
 [`iter().position()`] or the [memchr crate][memchr] to find the start of a
 potential match.
 
+It can also be configured to accept an iterator over bytes as input instead of
+a slice.
+
 ## Simple example
 
 To create a matcher to handle the four basic HTML entities, use a build script
@@ -46,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&lt;", "b'<'")
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
-        .render_slice(&mut out)?;
+        .render(&mut out)?;
 
     Ok(())
 }

--- a/examples/cli-iter.rs
+++ b/examples/cli-iter.rs
@@ -1,4 +1,4 @@
-use iter_matcher::TreeMatcher;
+use iter_matcher::{Input, TreeMatcher};
 use std::env;
 use std::io;
 use std::process::exit;
@@ -13,5 +13,6 @@ fn main() {
         }
         matcher.add(key_value[0].as_bytes(), format!("{:?}", key_value[1]));
     });
-    matcher.render_iter(&mut io::stdout()).unwrap();
+    matcher.set_input_type(Input::Iterator);
+    matcher.render(&mut io::stdout()).unwrap();
 }

--- a/examples/cli-slice.rs
+++ b/examples/cli-slice.rs
@@ -1,4 +1,4 @@
-use iter_matcher::TreeMatcher;
+use iter_matcher::{Input, TreeMatcher};
 use std::env;
 use std::io;
 use std::process::exit;
@@ -13,5 +13,6 @@ fn main() {
         }
         matcher.add(key_value[0].as_bytes(), format!("{:?}", key_value[1]));
     });
-    matcher.render_slice(&mut io::stdout()).unwrap();
+    matcher.set_input_type(Input::Slice);
+    matcher.render(&mut io::stdout()).unwrap();
 }

--- a/iter_matcher_tests/build.rs
+++ b/iter_matcher_tests/build.rs
@@ -1,4 +1,4 @@
-use iter_matcher::TreeMatcher;
+use iter_matcher::{Input, TreeMatcher};
 use std::env;
 use std::error::Error;
 use std::fs::{self, File};
@@ -44,7 +44,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         .disable_clippy(true)
-        .render_iter(&mut out)?;
+        .set_input_type(Input::Iterator)
+        .render(&mut out)?;
     writeln!(out)?;
 
     writeln!(out, "/// Match and return (bool, &[u8]).")?;
@@ -54,7 +55,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"ab", "(true, &[1])")
         .add(b"a", "(false, &[1])")
         .disable_clippy(true)
-        .render_slice(&mut out)?;
+        .set_input_type(Input::Slice)
+        .render(&mut out)?;
     writeln!(out)?;
 
     writeln!(out, "/// Decode basic HTML entities.")?;
@@ -64,7 +66,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
         .disable_clippy(false)
-        .render_iter(&mut out)?;
+        .set_input_type(Input::Iterator)
+        .render(&mut out)?;
     writeln!(out)?;
 
     writeln!(out, "/// Decode basic HTML entities.")?;
@@ -74,7 +77,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add(b"&gt;", "b'>'")
         .add(b"&quot;", "b'\"'")
         .disable_clippy(false)
-        .render_slice(&mut out)?;
+        .set_input_type(Input::Slice)
+        .render(&mut out)?;
     writeln!(out)?;
 
     writeln!(out, "/// Decode all HTML entities.")?;
@@ -83,19 +87,22 @@ fn main() -> Result<(), Box<dyn Error>> {
         serde_json::from_slice(&input)?;
     let mut matcher =
         TreeMatcher::new("pub fn all_entity_decode", "&'static str");
-    matcher.disable_clippy(true);
-    matcher.extend(input.iter().map(|(name, info)| {
-        (
-            name.as_bytes(),
-            format!("{:?}", info["characters"].as_str().unwrap()),
-        )
-    }));
-    matcher.render_iter(&mut out)?;
+    matcher
+        .disable_clippy(true)
+        .set_input_type(Input::Iterator)
+        .extend(input.iter().map(|(name, info)| {
+            (
+                name.as_bytes(),
+                format!("{:?}", info["characters"].as_str().unwrap()),
+            )
+        }));
+    matcher.render(&mut out)?;
     writeln!(out)?;
 
     writeln!(out, "/// Decode all HTML entities.")?;
     matcher.fn_name = "pub fn all_entity_decode_slice".to_string();
-    matcher.render_slice(&mut out)?;
+    matcher.set_input_type(Input::Slice);
+    matcher.render(&mut out)?;
     writeln!(out)?;
 
     Ok(())


### PR DESCRIPTION
It might be clearer to have separate structs to generate slice and iterator matchers, but I think it would involve too much duplicated code. This seems like a simple solution.