### PR TITLE
Use BTreeMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* **Breaking:** Changed the type of the public field `TreeNode::branch` from
+  `HashMap<u8, TreeNode>` to `BTreeMap<u8, TreeNode>`.
+
+  This makes the generated `match` arms appear in a deterministic order.
+
 ## Release 0.4.0 (2025-10-31)
 
 * Changed `TreeMatcher` to use a flat slice match, e.g. `match slice { [1, 2, 3,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,6 +1,6 @@
 //! Code for the [`TreeMatcher`].
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::fmt;
 use std::fs;
@@ -756,7 +756,7 @@ pub struct TreeNode {
     ///
     /// If none of these characters match, then return `leaf` as the match
     /// (it might be None, indicating that nothing matches).
-    pub branch: HashMap<u8, Self>,
+    pub branch: BTreeMap<u8, Self>,
 }
 
 impl TreeNode {


### PR DESCRIPTION
Without BTreeMap, the generated branches can change on every run. With BTreeMap the ordering is deterministic & also easier when looking at the generated code.
The public breaking change can be avoided by converting to BTreeMap at compile time.