### PR TITLE
Switch `FlatMatcher::arms` to `BTreeMap` as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
-* **Breaking:** Changed the type of the public field `TreeNode::branch` from
-  `HashMap<u8, TreeNode>` to `BTreeMap<u8, TreeNode>`.
+### Breaking changes
+
+* Changed the type of the public fields `TreeNode::branch` and `FlatMatcher::arms` from `HashMap` to `BTreeMap`.
 
   This makes the generated `match` arms appear in a deterministic order.
+
+  Thanks to [Utkarsh Gupta](https://github.com/utkarshgupta137) for the [PR](https://github.com/danielparks/matchgen/pull/95)!
 
 ## Release 0.4.0 (2025-10-31)
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1,7 +1,7 @@
 //! Code for the [`FlatMatcher`].
 
 use std::cmp;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::fmt;
 use std::fs;
@@ -116,7 +116,11 @@ pub struct FlatMatcher {
     pub doc: Option<String>,
 
     /// The arms of the match statement.
-    pub arms: HashMap<Vec<u8>, String>,
+    ///
+    /// Note that the rendered match arms will be ordered by decreasing key
+    /// length first, then lexicographically. Simply iterating the arms will be
+    /// in lexicographic order.
+    pub arms: BTreeMap<Vec<u8>, String>,
 }
 
 impl FlatMatcher {
@@ -140,7 +144,7 @@ impl FlatMatcher {
             disable_clippy: false,
             must_use: true,
             doc: None,
-            arms: HashMap::default(),
+            arms: BTreeMap::default(),
         }
     }
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -646,7 +646,7 @@ impl FlatMatcher {
             "{fn_name}({parameter}: &[u8]) -> (Option<{return_type}>, {remainder_type}) {{",
             fn_name = self.fn_name(),
             parameter = parameter,
-            return_type = &self.return_type,
+            return_type = self.return_type,
             remainder_type = if self.return_slice { "&[u8]" } else { "usize" },
         )?;
 


### PR DESCRIPTION
- **Switch `FlatMatcher::arms` to `BTreeMap` as well.**
  

- **+nightly lint: remove unneeded `&`.**
  