### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.5.0 (2026-05-21)
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "matchgen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bstr",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ matchgen = { path = "." }
 
 [package]
 name = "matchgen"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Daniel Parks <oss-matchgen@demonhorse.org>"]
 description = "Generate functions to quickly map byte string prefixes to values"
 homepage = "https://github.com/danielparks/matchgen"


### PR DESCRIPTION
### Breaking changes

* Changed the type of the public fields `TreeNode::branch` and `FlatMatcher::arms` from `HashMap` to `BTreeMap`.

  This makes the generated `match` arms appear in a deterministic order.

  Thanks to [Utkarsh Gupta](https://github.com/utkarshgupta137) for the [PR](https://github.com/danielparks/matchgen/pull/95)!
